### PR TITLE
Add Array-Check for print-index

### DIFF
--- a/packages/preview/acrostiche/0.3.0/acrostiche.typ
+++ b/packages/preview/acrostiche/0.3.0/acrostiche.typ
@@ -114,11 +114,15 @@
   
     // print the acronyms
     for acr in acr-list{
+      let acr-long = acronyms.at(acr)
+      let acr-long = if type(acr-long) == array {
+        acr-long.at(0)
+      } else {acr-long}
       table(
         columns: (20%,80%),
         stroke:none,
         inset: 0pt,
-        [*#acr#delimiter*], [#acronyms.at(acr).at(0)\ ]
+        [*#acr#delimiter*], [#acr-long\ ]
       )
     }
 


### PR DESCRIPTION
I forgot about the trailing comma after my initial tests and when getting back to the printed list got confused why it only prints the first letter.

This pr fixes the issue by using the value directly if it is not an array, and else using the first value of the array. 