### PR TITLE
feat: new version that supports printing the full version of an acronym

### DIFF
--- a/packages/preview/acrostiche/0.3.3/LICENSE
+++ b/packages/preview/acrostiche/0.3.3/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2023 Arthur Grisel-Davy
+Copyright (c) 2023 Aurel Weinhold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preview/acrostiche/0.3.3/README.md
+++ b/packages/preview/acrostiche/0.3.3/README.md
@@ -1,0 +1,68 @@
+# Acrostiche (0.3.2)
+
+Manages acronyms so you don't have to.
+
+## Quick Start
+
+```
+#import "@preview/acrostiche:0.3.2": *
+
+#init-acronyms((
+  "WTP": ("Wonderful Typst Package","Wonderful Typst Packages"),
+))
+
+Acrostiche is a #acr("WTP")! This #acr("WTP") enables easy acronyms manipulation.
+
+Its Main features are auto-expansion of the first occurence, global or selective expansion reset #reset-all-acronyms(), implicit or manual plural form support (there may be multiple #acrpl("WTP")), and customizable index printing. Have Fun!
+```
+
+
+## Usage
+
+The main goal of Acrostiche is to keep track of which acronyms to define.
+
+### Define acronyms
+First, define the acronyms in a dictionary, with the keys being the acronyms and the values being arrays of their definitions.
+If there is only a singular version of the definition, the array contains only one value.
+If there are both singular and plural versions, define the definition as an array where the first item is the singular definition and the second item is the plural.
+Then, initialize Arostiche with the acronyms you just defined with the `#init-acronyms(...)` function:
+
+Here is a sample of the `acronyms.typ` file:
+```
+#import "@preview/acrostiche:0.3.2": *
+
+#init-acronyms((
+  "NN": ("Neural Network"),
+  "OS": ("Operating System",),
+  "BIOS": ("Basic Input/Output System", "Basic Input/Output Systems"), 
+)) 
+```
+
+### Call Acrostiche functions
+Once the acronyms are defined, you can use them in the text with the `#acr(...)` function.
+The argument is the acronym as a string (for example, "BIOS"). On the first call of the function, it prints the acronym with its definition (for example, "Basic Input/Output System (BIOS)").
+On the next calls, it prints only the acronym.
+
+To get the plural version of the acronym, you can use the `#acrpl(...)` function that adds an 's' after the acronym.
+If a plural version of the definition is provided, it will be used if the first use of the acronym is plural.
+Otherwise, the singular version is used, and a trailing 's' is added.
+
+At any point in the document, you can reset acronyms with the functions `#reset-acronym(...)` (for a single acronym) or `reset-all-acronyms()` (to reset all acronyms). After a reset, the next use of the acronym is expanded.
+
+You can also print an index of all acronyms used in the document with the `#print-index()` function.
+The index is printed as a section for which you can choose the heading level, the numbering, and the outline parameters (with respectively the `level: int`, `numbering: none | string | function`, and `outlined: bool` parameters).
+You can also choose their order with the `sorted: string` parameter that accepts either an empty string (print in the order they are defined), "up" (print in ascending alphabetical order), or "down" (print in descending alphabetical order).
+The index contains all the acronyms you defined. You can use the `title: string` parameter to change the name of the heading for the index section.
+The default value is "Acronyms Index". Passing an empty string for `title` results in the index having no heading (i.e., no section for the index).
+You can customize the string displayed after the acronym in the list with the `delimiter: ":"` parameter.
+To adjust the spacing between the acronyms adjust the `row-gutter: auto | int | relative | fraction | array` parameter, the default is `2pt`.
+
+Finally, you can call the `#display-def(...)` function to display the definition of an acronym. Set the `plural` parameter to true to get the plural version.
+
+## Possible Errors:
+
+ * If an acronym is not defined, an error will tell you which one is causing the error. Simply add it to the dictionary or check the spelling.
+ * For every acronym "ABC" that you define, the state named "acronym-state-ABC" is initialized and used. To avoid errors, do not try to use this state manually for other purposes. Similarly, the state named "acronyms" is reserved to Acrostiche; avoid using it.
+ * `display-def` leverages the state `display` function and only works if the return value is actually printed in the document. For more information on states, see the Typst documentation on states.
+
+If you notice any bug or want to contribute a new feature, please open an issue or a merge request on the fork [Grisely/packages](https://github.com/Grisely/packages)

--- a/packages/preview/acrostiche/0.3.3/acrostiche.typ
+++ b/packages/preview/acrostiche/0.3.3/acrostiche.typ
@@ -1,0 +1,141 @@
+// Acrostiche package for Typst
+// Author: Grizzly
+
+
+#let acros = state("acronyms",none)
+#let init-acronyms(acronyms) = {
+  acros.update(acronyms)
+}
+
+#let reset-acronym(term) = { 
+  // Reset a specific acronym. It will be expanded on next use.
+    state("acronym-state-" + term, false).update(false)
+}
+
+#let reset-all-acronyms() = { 
+  // Reset all acronyms. They will all be expanded on the next use.
+  state("acronyms",none).display(acronyms=>
+    for acr in acronyms.keys() {
+      state("acronym-state-" + acr, false).update(false)
+  })
+}
+
+#let display-def(plural: false, acr) = {
+  //
+  if plural{
+    state("acronyms",none).display(acronyms=>{
+      if acr in acronyms{
+        let defs = acronyms.at(acr)
+        if type(defs) == "string"{ // If user forgot the trailing comma the type is string
+          defs
+        }else if type(defs)== "array"{
+          if acronyms.at(acr).len() == 0{panic("No definitions found for acronym "+acr+". Make sure it is defined in the dictionary passed to #init-acronyms(dict)")
+          }else if acronyms.at(acr).len() == 1{
+            acronyms.at(acr).at(0)+"s"
+          }else{
+            acronyms.at(acr).at(1)
+          }
+        }else{
+          panic("Definitions should be arrays of one or two strings. Definition of "+acr+ " is: "+type(defs))
+        }
+      }else{
+        panic(acr+" is not a key in the acronyms dictionary.")
+      }
+    })
+  }else{
+    state("acronyms",none).display(acronyms=>{
+      if acr in acronyms{
+        let defs = acronyms.at(acr)
+        if type(defs) == "string"{ // If user forgot the trailing comma the type is string
+          defs
+        }else if type(defs)== "array"{
+          if acronyms.at(acr).len() == 0{panic("No definitions found for acronym "+acr+". Make sure it is defined in the dictionary passed to #init-acronyms(dict)")
+          }else{
+            acronyms.at(acr).at(0)
+          }
+        }else{
+          panic("Definitions should be arrays of one or two strings. Definition of "+acr+ " is: "+type(defs))
+        }
+      }else{
+        panic(acr+" is not a key in the acronyms dictionary.")
+      }
+      
+      })
+  }
+}
+
+#let acrfull(acr) = {
+  //Intentionally display an acronym in its full form. Does not expand it and does not update state.
+  [#display-def(plural: false, acr)]
+}
+
+#let acrfullpl(acr) = {
+  //Intentionally display an acronym in its full form in plural. Does not expand it and does not update state.
+  [#display-def(plural: true, acr)]
+}
+
+#let acr(acr) = {
+  // Display an acronym in the singular form. Expands it if used for the first time.
+  
+  // Generate the key associated with this acronym
+  let state-key = "acronym-state-" + acr
+  // Create a state to keep track of the expansion of this acronym
+  state(state-key,false).display(seen => {if seen{acr}else{[#display-def(plural: false, acr) (#acr)]}})
+  state(state-key,false).update(true)
+}
+
+#let acrpl(acr) = {
+  // Display an acronym in the plural form. Expands it if used for the first time. 
+    
+  // Generate the key associated with this acronym
+  let state-key = "acronym-state-" + acr
+  // Create a state to keep track of the expansion of this acronym
+  state(state-key,false).display(seen => {if seen{acr+"s"}else{[#display-def(plural: true, acr) (#acr\s)]}})
+  state(state-key,false).update(true)
+}
+
+#let print-index(level: 1, numbering: none, outlined: false, sorted:"",
+                 title:"Acronyms Index", delimiter:":", row-gutter: 2pt) = {
+  //Print an index of all the acronyms and their definitions.
+  // Args:
+  //   level: level of the heading. Default to 1.
+  //   outlined: make the index section outlined. Default to false
+  //   sorted: define if and how to sort the acronyms: "up" for alphabetical order, "down" for reverse alphabetical order, "" for no sort (print in the order they are defined). If anything else, sort as "up". Default to ""
+  //   title: set the title of the heading. Default to "Acronyms Index". Passing an empty string will result in removing the heading.
+  //   delimiter: String to place after the acronym in the list. Defaults to ":"
+
+  // assert on input values to avoid cryptic error messages
+  assert(sorted in ("","up","down"), message:"Sorted must be a string either \"\", \"up\" or \"down\"")
+
+  if title != ""{
+    heading(level: level, numbering: numbering, outlined: outlined)[#title]
+  }
+
+  state("acronyms",none).display(acronyms=>{
+    
+    // Build acronym list
+    let acr-list = acronyms.keys()
+
+    // order list depending on the sorted argument
+    if sorted!="down"{
+      acr-list = acr-list.sorted()
+    }else{
+      acr-list = acr-list.sorted().rev()
+    }
+  
+    // print the acronyms
+    table(
+      columns: (20%,80%),
+      stroke: none,
+      row-gutter: row-gutter,
+      ..for acr in acr-list{
+        let acr-long = acronyms.at(acr)
+        let acr-long = if type(acr-long) == array {
+          acr-long.at(0)
+        } else {acr-long}
+        ([*#acr#delimiter*], acr-long)
+      }
+    )
+})
+}
+

--- a/packages/preview/acrostiche/0.3.3/typst.toml
+++ b/packages/preview/acrostiche/0.3.3/typst.toml
@@ -1,0 +1,8 @@
+[package]
+name = "acrostiche"
+version = "0.3.3"
+entrypoint = "acrostiche.typ"
+repository = "https://github.com/Grisely/packages"
+authors = ["Grizzly", "Aurel Weinhold"]
+license = "MIT"
+description = "Manage acronyms and their definitions in Typst."


### PR DESCRIPTION
I added a function (and its plural version) to display the expanded / full form of an acronym, without messing with state. 

Sometimes the expanded use of an acronym is useful to avoid constant repetition of the short form, in which case an explanation (expanded form + short form) is not needed. 

`#reset-acronym(...)` almost allows this behaviour, but a) appends the short form as explanation and b) is less convenient as it requires two statements.

As such I would appreciate if the PR was accepted, as I currently use a modified version locally.


I am not sure about best practices, but I already placed it in a new version folder, so the changes to the file are a bit hard to trace. The concrete changes are: 
```
#let acrfull(acr) = {
  //Intentionally display an acronym in its full form. Does not expand it and does not update state.
  [#display-def(plural: false, acr)]
}

#let acrfullpl(acr) = {
  //Intentionally display an acronym in its full form in plural. Does not expand it and does not update state.
  [#display-def(plural: true, acr)]
}
```



