### PR TITLE
Replace table with grid

### DIFF
--- a/packages/preview/acrostiche/0.4.1/acrostiche.typ
+++ b/packages/preview/acrostiche/0.4.1/acrostiche.typ
@@ -221,9 +221,8 @@
     }
   
     // print the acronyms
-    table(
+    grid(
       columns: (20%,80%),
-      stroke: none,
       row-gutter: row-gutter,
       ..for acr in acr-list{
         ([*#display-short(acr, plural:false)#delimiter*], display-def(acr,plural:false))


### PR DESCRIPTION
In `print-index`, you used `table`. This is problematic for two reasons:
1. [In the documentation, it says to use grid in your case.](https://typst.app/docs/reference/model/table/) This also helps with accessibility.
2. When I restyle tables in my program using `set` rules, it also changes the acrostiche index.

`grid` is plug-and-play, so I just replaced it.