### PR TITLE
feat: add column-ratio for print-index function

### DIFF
--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -205,7 +205,7 @@
 
 
 #let print-index(level: 1, numbering: none, outlined: false, sorted:"",
-                 title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false) = {
+                 title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column-ratio: 0.25,) = {
   //Print an index of all the acronyms and their definitions.
   // Args:
   //   level: level of the heading. Default to 1.
@@ -217,6 +217,7 @@
 
   // assert on input values to avoid cryptic error messages
   assert(sorted in ("","up","down"), message:"Sorted must be a string either \"\", \"up\" or \"down\"")
+  assert(0 <= column-ratio and column-ratio <= 1, message: "column-ratio must be a value between 0 and 1.")
 
   if title != ""{
     heading(level: level, numbering: numbering, outlined: outlined)[#title]
@@ -251,8 +252,10 @@
     }
   
     // print the acronyms
+    let col1 = column-ratio / (1 + column-ratio)
+    let col2 = 1 - col1
     grid(
-      columns: (20%,80%),
+      columns: (col1 * 100%, col2 * 100%),
       row-gutter: row-gutter,
       ..for acr in acr-list{
         ([*#display-short(acr, plural:false)#delimiter*], display-def(acr,plural:false))


### PR DESCRIPTION
I added an additional parameter for the print-index function which describes the ratio of the grid.

The default is 0.25 = 1/4 which is calculated as a ratio of 1 to 4 i.e. 20% to 80%.

The use-case I had for this was in the context of writing a paper that has split the page into 2 columns. Printing the index in a column with long acronyms leads to overlap of the acronym and its definition.