### PR TITLE
feat: add clickable links to index

### DIFF
--- a/packages/preview/acrostiche/dev/README.md
+++ b/packages/preview/acrostiche/dev/README.md
@@ -74,6 +74,7 @@ Both functions have shortcuts with `#racr(...)` and `#raacr(...)`.
 
 You can also print an index of all acronyms used in the document with the `#print-index()` function.
 The index is printed as a section for which you can choose the heading level, the numbering, and the outline parameters (with respectively the `level: int`, `numbering: none | string | function`, and `outlined: bool` parameters).
+Clicking on an acronym in the text links to the index, this can be disabled with `clicking: false`.
 You can also choose their order with the `sorted: string` parameter that accepts either an empty string (print in the order they are defined), "up" (print in ascending alphabetical order), or "down" (print in descending alphabetical order).
 By default, the index contains all the acronyms you defined. You can choose to only display acronyms that are actually used in the document by passing `used-only: true` to the function. Warning, the detection of used acronym uses the states at the end of the document. Thus, if you reset an acronym and do not use it again until the end, it will not appear in the index.
  You can use the `title: string` parameter to change the name of the heading for the index section.

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -218,7 +218,7 @@
 
 
 #let print-index(level: 1, numbering: none, outlined: false, sorted:"",
-title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column-ratio: 0.25) = {
+title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column-ratio: 0.25, clickable:true) = {
   //Print an index of all the acronyms and their definitions.
   // Args:
   //   level: level of the heading. Default to 1.
@@ -241,7 +241,10 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
 
     let acronyms = acros.get()
     let acr-list = acronyms.keys()
-    index.update(true)  
+
+    if clickable {
+      index.update(true)  
+    }
 
     if used-only{
       // Select only acronyms where state is true at the end of the document.

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -228,6 +228,7 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
   //   delimiter: String to place after the acronym in the list. Defaults to ":"
   //   used-only: if true, only include in the index the acronyms that are used in the document. Warning, if you reset acronyms and don't used them after, they may not appear.
   //   column-ratio: a float positive value that indicate the width ratio of the first column (acronyms) with respect to the second (definitions).
+  // clickable: if true, create a clickable link to the acryonym in the first acronym index
 
   // assert on input values to avoid cryptic error messages
   assert(sorted in ("","up","down"), message:"Sorted must be a string either \"\", \"up\" or \"down\"")
@@ -242,9 +243,6 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
     let acronyms = acros.get()
     let acr-list = acronyms.keys()
 
-    if clickable {
-      index.update(true)  
-    }
 
     if used-only{
       // Select only acronyms where state is true at the end of the document.
@@ -274,9 +272,17 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
       columns: (col1 * 100%, col2 * 100%),
       row-gutter: row-gutter,
       ..for acr in acr-list{
-        ([*#display-short(acr, plural:false)#label(acr)#delimiter*], display-def(acr,plural:false))
+        // check if a label for a link should be created and if it is the first acronyms index, since it can not create multiple labels
+        if clickable and (not index.get()) {
+          ([*#display-short(acr, plural:false)#delimiter#label(acr)*], display-def(acr,plural:false))
+        } else {
+          ([*#display-short(acr, plural:false)#delimiter*], display-def(acr,plural:false))
+        }
       }
     )
+    if clickable {
+      index.update(true)  
+    }
   }
 }
 

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -3,6 +3,7 @@
 
 
 #let acros = state("acronyms",none)
+#let index = state("index", false)
 #let init-acronyms(acronyms) = {
   let states = (:)
   for (acr, defs) in acronyms{
@@ -23,24 +24,36 @@
     let acronyms = acros.get()
     if acr in acronyms{
       let defs = acronyms.at(acr).at(0)
+      let out
       if type(defs) == dictionary{
         if plural {
           if "short-pl" in defs{
-            defs.at("short-pl")
+            out = defs.at("short-pl")
           }else{
-            [#acr\s]
+            out = [#acr\s]
           }
         }else{
           if "short" in defs{
-            defs.at("short")
-          }else{acr}
+            out = defs.at("short")
+          }else{
+            out = acr
+          }
         }
       }else{
         if plural{
-          [#acr\s]
+          out = [#acr\s]
+        }else{
+          out = acr
         }
-        else{acr}
       }
+
+      // add link if index is printed
+      if index.final() {
+        link(label(acr), out)
+      }else{
+        out
+      }
+      
     }else{
       panic("Could not display the short version of an acronym not defined: "+acr)
     }
@@ -225,11 +238,10 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
   }
 
   context{
-    
 
-      
     let acronyms = acros.get()
     let acr-list = acronyms.keys()
+    index.update(true)  
 
     if used-only{
       // Select only acronyms where state is true at the end of the document.
@@ -259,7 +271,7 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
       columns: (col1 * 100%, col2 * 100%),
       row-gutter: row-gutter,
       ..for acr in acr-list{
-        ([*#display-short(acr, plural:false)#delimiter*], display-def(acr,plural:false))
+        ([*#display-short(acr, plural:false)#label(acr)#delimiter*], display-def(acr,plural:false))
       }
     )
   }

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -49,7 +49,7 @@
 
       // add link if index is printed
       if index.final() {
-        link(label(acr), out)
+        link(label("acrostiche-"+acr), out)
       }else{
         out
       }
@@ -274,7 +274,7 @@ title:"Acronyms Index", delimiter:":", row-gutter: 2pt, used-only: false, column
       ..for acr in acr-list{
         // check if a label for a link should be created and if it is the first acronyms index, since it can not create multiple labels
         if clickable and (not index.get()) {
-          ([*#display-short(acr, plural:false)#delimiter#label(acr)*], display-def(acr,plural:false))
+          ([*#display-short(acr, plural:false)#delimiter#label("acrostiche-"+acr)*], display-def(acr,plural:false))
         } else {
           ([*#display-short(acr, plural:false)#delimiter*], display-def(acr,plural:false))
         }

--- a/packages/preview/acrostiche/dev/test.typ
+++ b/packages/preview/acrostiche/dev/test.typ
@@ -85,8 +85,10 @@ Display long plural shortcut: #aclp("ada").\
 #ref("Display long plural shortcut: Advanced Definitions Acronyms.")
 
 == Print Index Variations
+Acronyms can be clicked and link to the first index table that has the default flag `clickable: true`.
 
-#print-index()
+#print-index(clickable: false)
+#print-index(title:"Clickable acronyms", clickable: true)
 
 #print-index(title:"Sorted Empty",sorted:"")
 #print-index(title:"Sorted up",   sorted:"up")


### PR DESCRIPTION
I added that when you click on an acronym it jumps to the acronyms index. 
In case no index table exits this should do nothing, it can also be disabled with the clickable option from print-index 