### PR TITLE
Bugfixes and consistency

### DIFF
--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -213,7 +213,9 @@
 #let acrfullpl(acr) = {[#display-def(acr, plural: true) (#display-short(acr,plural:true))]}
 #let acrfullplcap(acr) = {[#display-def(acr, plural: true) (#display-short(acr,plural:true))]}
 
-#let acrfullcap(acr) = {[#display-def(acr, plural: false, cap: true) (#display-short(acr,plural:true))]}
+#let acrfullcap(acr) = {
+  [#display-def(acr, plural: false, cap: true) (#display-short(acr, plural: false))]
+}
 
 // define shortcuts
 

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -211,7 +211,9 @@
 }
 
 #let acrfullpl(acr) = {[#display-def(acr, plural: true) (#display-short(acr,plural:true))]}
-#let acrfullplcap(acr) = {[#display-def(acr, plural: true) (#display-short(acr,plural:true))]}
+#let acrfullplcap(acr) = {
+  [#display-def(acr, plural: true, cap: true) (#display-short(acr, plural: true))]
+}
 
 #let acrfullcap(acr) = {
   [#display-def(acr, plural: false, cap: true) (#display-short(acr, plural: false))]

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -205,18 +205,18 @@
 #let acrpl(acronym) = {acr(acronym,plural:true)} // argument renamed acronym to differentiate with function acr
 #let acrcap(acronym) = {acr(acronym,plural: false, cap: true)}
 
+// Intentionally display an acronym in its full form. Do not update state.
 #let acrfull(acr) = {
-  //Intentionally display an acronym in its full form. Do not update state.
-  [#display-def(acr, plural: false) (#display-short(acr))]
+  [#display-def(acr, plural: false)~(#display-short(acr))]
 }
-
-#let acrfullpl(acr) = {[#display-def(acr, plural: true) (#display-short(acr,plural:true))]}
+#let acrfullpl(acr) = {
+  [#display-def(acr, plural: true)~(#display-short(acr, plural: true))]
+}
 #let acrfullplcap(acr) = {
-  [#display-def(acr, plural: true, cap: true) (#display-short(acr, plural: true))]
+  [#display-def(acr, plural: true, cap: true)~(#display-short(acr, plural: true))]
 }
-
 #let acrfullcap(acr) = {
-  [#display-def(acr, plural: false, cap: true) (#display-short(acr, plural: false))]
+  [#display-def(acr, plural: false, cap: true)~(#display-short(acr, plural: false))]
 }
 
 // define shortcuts


### PR DESCRIPTION
- Fix usage of `plural` in `acrfullcap`
- Fix usage of `cap` in `acrfullplcap`
- Consistent usage of non-breaking hyphen between long form and acronym; compare to usage in `acr`
