### PR TITLE
Fix caps breaking auto-generated plural

### DIFF
--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -228,6 +228,8 @@
 #let acrpl(acronym) = acr(acronym, plural: true)
 /// Display capitalized version of an acronym
 #let acrcap(acronym) = acr(acronym, plural: false, cap: true)
+/// Display plural, capitalized version of an acronym
+#let acrplcap(acronym) = acr(acronym, plural: true, cap: true)
 
 // Intentionally display an acronym in its full form. Do not update state.
 

--- a/packages/preview/acrostiche/dev/acrostiche.typ
+++ b/packages/preview/acrostiche/dev/acrostiche.typ
@@ -18,10 +18,10 @@
   }
   // for plural add an s if they are not explicitly provided
   if "short-pl" not in definitions {
-    definitions.insert("short-pl", [#definitions.at("short")\s])
+    definitions.insert("short-pl", definitions.at("short") + "s")
   }
   if "long-pl" not in definitions {
-    definitions.insert("long-pl", [#definitions.at("long")\s])
+    definitions.insert("long-pl", definitions.at("long") + "s")
   }
 
   definitions


### PR DESCRIPTION
`#acr("...", plural: true, cap: true)` panics "Trying to capitalize the first letter of a non-string element" if there is no explicitly defined plural for the acronym. This is fixed by changing the auto-generated plurals to strings rather than content items.

Also `acrplcap` was missing despite `acrfullplcap` being present.